### PR TITLE
Update `pypiserver` to `1.5.0` for integration testing

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   pypiserver:
-    image: pypiserver/pypiserver:v1.4.2
+    image: pypiserver/pypiserver:v1.5.0
     volumes:
       - type: bind
         source: ./auth


### PR DESCRIPTION
See https://github.com/pypiserver/pypiserver/releases/tag/v1.5.0.

This looks to be largely a maintainability improvement release.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
