### PR TITLE
Update Twine to 4.0.1

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "TWINE_VERSION" {
-  default = "4.0.0"
+  default = "4.0.1"
 }
 
 group "default" {


### PR DESCRIPTION
Picks up some logging-related tweaks; see
https://twine.readthedocs.io/en/stable/changelog.html#twine-4-0-1-2022-06-01.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
