### PR TITLE
Update and lock Buildkite images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_COMPOSE_CHECK := docker-compose run --rm
+DOCKER_COMPOSE_CHECK := docker compose run --rm
 NONROOT_DOCKER_COMPOSE_CHECK := $(DOCKER_COMPOSE_CHECK) --user=$(shell id --user):$(shell id --group)
 
 PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-workdir: &read-only-workdir
     type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ x-common-variables:
 
 services:
   plugin-linter:
-    image: buildkite/plugin-linter:latest # the only available tag
+    image: buildkite/plugin-linter@sha256:833b1ce8326b038c748c8f04d317045205e115b1732a6842ec4a957f550fe357
     command: ["--id", "grapl-security/pypi"]
     volumes:
       - *read-only-plugin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - *read-only-plugin
 
   plugin-tester:
-    image: buildkite/plugin-tester:latest # the only available tag
+    image: buildkite/plugin-tester:v2.0.0
     volumes:
       - *read-only-plugin
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty


### PR DESCRIPTION
Our weekly maintenance pipeline run failed, which brought this weekend's [`buildkite-plugin-tester v2.0.0 release](https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v2.0.0) to our attention. It updates several bits of BATS infrastructure, but also introduces a breaking change (this is the ultimate cause of our maintenance pipeline failures).

This PR locks us to the `v2.0.0` release of the `plugin-tester` image, and addresses the breaking change.

I also noticed that our use of the `buildkite/plugin-linter` image was also pinned to `latest`, just as our `buildkite/plugin-tester` image was. There are no formal release of this image (yet 🤞), so I've pinned it to a concrete SHA to be safe.

While making these fixes, I also took the liberty of shifting our Docker Compose usage explicitly to v2, as we have been doing across all our projects lately.