### PR TITLE
Update `pypiserver` to `v1.5.1`

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   pypiserver:
-    image: pypiserver/pypiserver:v1.5.0
+    image: pypiserver/pypiserver:v1.5.1
     volumes:
       - type: bind
         source: ./auth


### PR DESCRIPTION
This is a minor "keeping up" version bump.

https://github.com/pypiserver/pypiserver/releases/tag/v1.5.1

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
